### PR TITLE
Introduced icon overrides to allow custom icon names, codepoints and ligatures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,13 @@ const builder = new IconFontBuildr ({
     'backup',
     'bug_report',
     'amazon',
-    'android-debug-bridge',
-    'public_domain'
+    'public_domain',
+    { // optional form for advanced glyph configuration
+      icon: 'android-debug-bridge',
+      name: 'android debug icon',
+      codepoints: [ '\E042', '\E064' ],
+      ligatures: [ 'DEBUG', 'DEBUG2' ]
+    }
   ],
   output: {
     // codepoints: true, // Enable support for codepoints

--- a/test/index.js
+++ b/test/index.js
@@ -29,7 +29,7 @@ describe ( 'Icon Font Buildr', it => {
         {
           icon: 'android-debug-bridge',
           name: 'my debug icon',
-          codepoints: [ '\E042', '\E000' ],
+          codepoints: [ '\E042', '\E064' ],
           ligatures: [ 'DEBUG', 'DEBUG2' ]
         },
         'public_domain'

--- a/test/index.js
+++ b/test/index.js
@@ -29,14 +29,8 @@ describe ( 'Icon Font Buildr', it => {
         {
           icon: 'android-debug-bridge',
           name: 'my debug icon',
-          codepoint: '\uE042',
-          ligatures: 'DEBUG'
-        },
-        {
-          icon: 'android-debug-bridge',
-          name: 'my debug icon 2',
-          codepoint: '\uE000',
-          ligature: 'DEBUG2'
+          codepoints: [ '\E042', '\E000' ],
+          ligatures: [ 'DEBUG', 'DEBUG2' ]
         },
         'public_domain'
       ],

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,12 @@ describe ( 'Icon Font Buildr', it => {
         'backup',
         'bug_report',
         'amazon',
-        'android-debug-bridge',
+        {
+          src: 'android-debug-bridge',
+          name: 'my debug icon',
+          codepoint: '\E042',
+          ligature: 'DEBUG'
+        },
         'public_domain'
       ],
       output: {

--- a/test/index.js
+++ b/test/index.js
@@ -29,8 +29,14 @@ describe ( 'Icon Font Buildr', it => {
         {
           icon: 'android-debug-bridge',
           name: 'my debug icon',
-          codepoints: [ '\E042', '\E000' ],
-          ligatures: [ 'DEBUG', 'DEBUG2' ]
+          codepoint: '\uE042',
+          ligatures: 'DEBUG'
+        },
+        {
+          icon: 'android-debug-bridge',
+          name: 'my debug icon 2',
+          codepoint: '\uE000',
+          ligature: 'DEBUG2'
         },
         'public_domain'
       ],

--- a/test/index.js
+++ b/test/index.js
@@ -22,12 +22,15 @@ describe ( 'Icon Font Buildr', it => {
       icons: [
         'backup',
         'bug_report',
-        'amazon',
         {
-          src: 'android-debug-bridge',
+          icon: 'amazon',
+          name: 'amazonIcon'
+        },
+        {
+          icon: 'android-debug-bridge',
           name: 'my debug icon',
-          codepoint: '\E042',
-          ligature: 'DEBUG'
+          codepoints: [ '\E042', '\E000' ],
+          ligatures: [ 'DEBUG', 'DEBUG2' ]
         },
         'public_domain'
       ],


### PR DESCRIPTION
With this change it is now possible to define custom icon names, codepoints and ligature strings.

Example configuration:
```js
const builder = new IconFontBuildr ({
	// ...
	icons: [ // Name of the icons to download
		{
			src: 'some_icon_a',
			name: 'CUSTOM',
			ligature: 'foo',
			codepoint: '\uE042'
		},
		'some_icon_b' // legacy
	],
	// ...
});
```

Legacy configuration will not break as normal strings (line 10) will get converted to objects and get filled with default values to ensure the same result as before.