### PR TITLE
Add configuration for a custom logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ const builder = new IconFontBuildr ({
       'ttf',
       'woff',
       'woff2'
-    ]
+    ],
+    // logger: function(context, ...messages) {} // custom logging function 
   }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ class IconFontBuildr {
     this.config.sources = this.config.sources.map ( makeAbs );
     this.config.output.icons = makeAbs ( this.config.output.icons );
     this.config.output.fonts = makeAbs ( this.config.output.fonts );
+    this.config.output.logger = typeof this.config.output.logger === 'function' ? this.config.output.logger : ( context, ...messages ) => console.log ( ...messages )
 
   }
 
@@ -172,7 +173,7 @@ class IconFontBuildr {
 
       fs.writeFileSync ( dst, body );
 
-      console.log ( `Downloaded "${chalk.bold ( src )}"` );
+      this.config.output.logger ( 'icon-font-buildr', `Downloaded "${chalk.bold ( src )}"` );
 
       return true;
 
@@ -190,7 +191,7 @@ class IconFontBuildr {
 
     copy ( src, dst );
 
-    console.log ( `Copied "${chalk.bold ( src )}"` );
+    this.config.output.logger ( 'icon-font-buildr', `Copied "${chalk.bold ( src )}"` );
 
     return true;
 
@@ -277,7 +278,8 @@ class IconFontBuildr {
       centerHorizontally: true,
       fontHeight: 4096,
       fontName: this.config.output.fontName,
-      normalize: true
+      normalize: true,
+      log: ( ...messages ) => { this.config.output.logger( 'svgicons2svgfont', ...messages ) }
     });
 
     stream.pipe ( fs.createWriteStream ( this.paths.cache.fontSVG ) );


### PR DESCRIPTION
This allows for the definition of a custom logging function instead of using `console.log`.

The benefits include being able to filter messages by their `context` (or "sender") to e.g. mute output by the underlying `svgicons2svgfont` package (during font creating it prints "Font created" which might be confusing in CLI applications, as the font isn't created yet but still building).

This also allows for futher improvement of logging inside the package itself in the future.

**Example:**
```js
const builder = new IconFontBuildr ({
  // ...
  output: {
    // ...
    logger: function(context, ...messages) {
      if(context !== 'svgicons2svgfont') console.log(messages) // muting output for svgicons2svgfont
    }
  }
});
```