### PR TITLE
Fixed a race condition problem in 'buildFontSVG'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,10 +343,10 @@ class IconFontBuildr {
       });
 
       stream.pipe ( fs.createWriteStream ( this.paths.cache.fontSVG ) )
-        .on( 'finish',function() {
+        .on( 'finish', function() {
           resolve();
         })
-        .on( 'error',function( err ) {
+        .on( 'error', function( err ) {
           reject( err );
         });
 


### PR DESCRIPTION
I was working on something earlier when I noticed that the `svg2ttf` command failed when I was turning a lot of icons (over 400 in my case) into an icon font.

After some debugging I discovered, that the SVG file is not done being generated when the code attempts to turn it into a TTF file.

I fixed this lack of async handling by using the stream events `svgicons2svgfont` offers to only resolve the promise of the async method `buildFontSVG` when the SVG was actually completely written to and is safe to pick up again.

---

Don't get confused by the diff, I actually just wrapped that code with a promise and added the events, but since the indentation changed, GitHub seems to get a little lost there.